### PR TITLE
Support overclocking and underclocking the Gamecube CPU

### DIFF
--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -340,6 +340,7 @@ void SConfig::SaveCoreSettings(IniFile& ini)
 	core->Set("RunCompareClient", m_LocalCoreStartupParameter.bRunCompareClient);
 	core->Set("FrameLimit", m_Framelimit);
 	core->Set("FrameSkip", m_FrameSkip);
+	core->Set("Overclock", m_OCFactor);
 	core->Set("GFXBackend", m_LocalCoreStartupParameter.m_strVideoBackend);
 	core->Set("GPUDeterminismMode", m_LocalCoreStartupParameter.m_strGPUDeterminismMode);
 	core->Set("GameCubeAdapter", m_GameCubeAdapter);
@@ -574,6 +575,7 @@ void SConfig::LoadCoreSettings(IniFile& ini)
 	core->Get("FastDiscSpeed",             &m_LocalCoreStartupParameter.bFastDiscSpeed,    false);
 	core->Get("DCBZ",                      &m_LocalCoreStartupParameter.bDCBZOFF,          false);
 	core->Get("FrameLimit",                &m_Framelimit,                                  1); // auto frame limit by default
+	core->Get("Overclock",                 &m_OCFactor,                                    1.0f);
 	core->Get("FrameSkip",                 &m_FrameSkip,                                   0);
 	core->Get("GFXBackend",                &m_LocalCoreStartupParameter.m_strVideoBackend, "");
 	core->Get("GPUDeterminismMode",        &m_LocalCoreStartupParameter.m_strGPUDeterminismMode, "auto");

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -49,6 +49,7 @@ struct SConfig : NonCopyable
 	int m_InterfaceLanguage;
 	// framelimit choose
 	unsigned int m_Framelimit;
+	float m_OCFactor;
 	// other interface settings
 	bool m_InterfaceToolbar;
 	bool m_InterfaceStatusbar;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -327,6 +327,8 @@ void EmuThread()
 
 	Common::SetCurrentThreadName("Emuthread - Starting");
 
+	if (SConfig::GetInstance().m_OCFactor != 1.0f)
+		DisplayMessage("WARNING: running at non-native CPU clock! Game may not be stable.", 8000);
 	DisplayMessage(cpu_info.brand_string, 8000);
 	DisplayMessage(cpu_info.Summarize(), 8000);
 	DisplayMessage(core_parameter.m_strFilename, 3000);

--- a/Source/Core/Core/CoreTiming.cpp
+++ b/Source/Core/Core/CoreTiming.cpp
@@ -48,6 +48,7 @@ static Common::FifoQueue<BaseEvent, false> tsQueue;
 // event pools
 static Event *eventPool = nullptr;
 
+float lastOCFactor;
 int slicelength;
 static int maxSliceLength = MAX_SLICE_LENGTH;
 
@@ -82,6 +83,16 @@ static void FreeEvent(Event* ev)
 
 static void EmptyTimedCallback(u64 userdata, int cyclesLate) {}
 
+static int DowncountToCycles(int downcount)
+{
+	return (int)(downcount / lastOCFactor);
+}
+
+static int CyclesToDowncount(int cycles)
+{
+	return (int)(cycles * lastOCFactor);
+}
+
 int RegisterEvent(const std::string& name, TimedCallback callback)
 {
 	EventType type;
@@ -115,7 +126,8 @@ void UnregisterAllEvents()
 
 void Init()
 {
-	PowerPC::ppcState.downcount = maxSliceLength;
+	lastOCFactor = SConfig::GetInstance().m_OCFactor;
+	PowerPC::ppcState.downcount = CyclesToDowncount(maxSliceLength);
 	slicelength = maxSliceLength;
 	globalTimer = 0;
 	idledCycles = 0;
@@ -182,6 +194,7 @@ void DoState(PointerWrap &p)
 	p.Do(fakeDecStartTicks);
 	p.Do(fakeTBStartValue);
 	p.Do(fakeTBStartTicks);
+	p.Do(lastOCFactor);
 	p.DoMarker("CoreTimingData");
 
 	MoveEvents();
@@ -338,10 +351,10 @@ void SetMaximumSlice(int maximumSliceLength)
 
 void ForceExceptionCheck(int cycles)
 {
-	if (PowerPC::ppcState.downcount > cycles)
+	if (DowncountToCycles(PowerPC::ppcState.downcount) > cycles)
 	{
-		slicelength -= (PowerPC::ppcState.downcount - cycles); // Account for cycles already executed by adjusting the slicelength
-		PowerPC::ppcState.downcount = cycles;
+		slicelength -= (DowncountToCycles(PowerPC::ppcState.downcount) - cycles); // Account for cycles already executed by adjusting the slicelength
+		PowerPC::ppcState.downcount = CyclesToDowncount(cycles);
 	}
 }
 
@@ -392,9 +405,10 @@ void Advance()
 {
 	MoveEvents();
 
-	int cyclesExecuted = slicelength - PowerPC::ppcState.downcount;
+	int cyclesExecuted = slicelength - DowncountToCycles(PowerPC::ppcState.downcount);
 	globalTimer += cyclesExecuted;
-	PowerPC::ppcState.downcount = slicelength;
+	lastOCFactor = SConfig::GetInstance().m_OCFactor;
+	PowerPC::ppcState.downcount = CyclesToDowncount(slicelength);
 
 	while (first)
 	{
@@ -416,14 +430,14 @@ void Advance()
 	if (!first)
 	{
 		WARN_LOG(POWERPC, "WARNING - no events in queue. Setting downcount to 10000");
-		PowerPC::ppcState.downcount += 10000;
+		PowerPC::ppcState.downcount += CyclesToDowncount(10000);
 	}
 	else
 	{
 		slicelength = (int)(first->time - globalTimer);
 		if (slicelength > maxSliceLength)
 			slicelength = maxSliceLength;
-		PowerPC::ppcState.downcount = slicelength;
+		PowerPC::ppcState.downcount = CyclesToDowncount(slicelength);
 	}
 
 	if (advanceCallback)

--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -64,7 +64,7 @@ static Common::Event g_compressAndDumpStateSyncEvent;
 static std::thread g_save_thread;
 
 // Don't forget to increase this after doing changes on the savestate system
-static const u32 STATE_VERSION = 37;
+static const u32 STATE_VERSION = 38;
 
 enum
 {

--- a/Source/Core/DolphinWX/ConfigMain.h
+++ b/Source/Core/DolphinWX/ConfigMain.h
@@ -69,6 +69,7 @@ public:
 		ID_GAMECUBEPAGE,
 		ID_WIIPAGE,
 		ID_PATHSPAGE,
+		ID_ADVANCEDPAGE,
 	};
 
 private:
@@ -78,6 +79,7 @@ private:
 		ID_IDLESKIP,
 		ID_ENABLECHEATS,
 		ID_FRAMELIMIT,
+		ID_OVERCLOCK,
 
 		ID_CPUENGINE,
 
@@ -140,6 +142,8 @@ private:
 	wxCheckBox* SkipIdle;
 	wxCheckBox* EnableCheats;
 	wxChoice* Framelimit;
+	wxSlider* OCSlider;
+	wxStaticText* OCText;
 
 	// Advanced
 	wxRadioBox* CPUEngine;
@@ -238,6 +242,7 @@ private:
 	void UpdateGUI();
 	void OnClose(wxCloseEvent& event);
 
+	void UpdateCPUClock();
 	void CoreSettingsChanged(wxCommandEvent& event);
 
 	void DisplaySettingsChanged(wxCommandEvent& event);


### PR DESCRIPTION
Won't work with all games, but provides a nice way to spend extra CPU to make
a variable framerate game faster (e.g. Spyro or The Last Story), or to make
a game use less CPU at the cost of a lower framerate (e.g. Rogue Leader).